### PR TITLE
[Genie] Pipeline - 구축 (Gitea, Jenkins, k8s) 구축과 NFS-PV연동 템플릿을 추가합니다.

### DIFF
--- a/playbook/nfs_pv/nfs_pv_deploy.yml
+++ b/playbook/nfs_pv/nfs_pv_deploy.yml
@@ -1,0 +1,174 @@
+---
+### Deploy VirtualMachine ###
+- name: Genie를 활용한 Mold VM 배포 - NFS_PV Storage
+  hosts: localhost
+  gather_facts: no
+  vars:
+    base_path: "genie"
+    genie_ip: "localhost"
+  tasks:
+
+  - name: debug uuid stdout
+    set_fact:
+      uuid: "{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=5') }}"
+  - name: debug instance_nm stdout
+    set_fact:
+      nfs_storage_vm_nm: "{{ nfs_storage_vm }}-{{uuid}}"
+
+  - name: 가상머신 생성 "{{ nfs_storage_vm_nm }}"
+    cs_instance:
+      api_url: "{{ lookup('env', 'MOLD_API_URL') }}"
+      api_key: "{{ lookup('env', 'MOLD_API_KEY') }}"
+      api_secret: "{{ lookup('env', 'MOLD_SECRET_KEY') }}"
+      zone: "{{ lookup('env', 'MOLD_ZONE_NAME') }}"
+      name: "{{ nfs_storage_vm_nm }}"
+      template: "{{ nfs_storage_vm_temp }}"
+      service_offering: "{{ instance_computeoffer }}"
+      disk_offering: "{{ disk_offering }}"
+      ssh_key: "{{ lookup('env', 'MOLD_SSH_KEYPAIR') }}"
+      user_data: |
+          #cloud-config
+          disable_root: false
+          ssh_pwauth: true
+          runcmd:
+          - dnf install -y nfs-utils
+          - mkfs.ext4 /dev/sdb
+          - mkdir /nfs
+          - mount /dev/sdb /nfs
+          - echo "/nfs 10.10.0.0/16(rw,no_root_squash)" >> /etc/exports
+          - systemctl restart nfs-server
+      networks: "{{ lookup('env', 'AC_NETWORK_NAME') }}"
+    register: vm
+
+  - name: 생성한 가상머신이 부팅이 완료될 때까지 대기
+    wait_for_connection:
+      delay: 20
+      timeout: 300
+
+  - name: 배포한 가상머신 정보 수집
+    cs_instance_info:
+      api_url: "{{ lookup('env', 'MOLD_API_URL') }}"
+      api_key: "{{ lookup('env', 'MOLD_API_KEY') }}"
+      api_secret: "{{ lookup('env', 'MOLD_SECRET_KEY') }}"
+      name: "{{ nfs_storage_vm_nm }}"
+    delegate_to: localhost
+    register: vm
+
+  - name: 배포 가상머신 ip 정보 수집
+    debug:
+      msg: "{{ vm.instances[0].nic[0].ipaddress }}"
+
+  - name: Create Public IP
+    cs_ip_address:
+      api_url: "{{ lookup('env', 'MOLD_API_URL') }}"
+      api_key: "{{ lookup('env', 'MOLD_API_KEY') }}"
+      api_secret: "{{ lookup('env', 'MOLD_SECRET_KEY') }}"
+      zone: "{{ lookup('env', 'MOLD_ZONE_NAME') }}"
+      network: "{{ lookup('env', 'AC_NETWORK_NAME') }}"
+    register: ac_public_ip
+
+  - name: Public IP 정보 수집
+    debug:
+      msg: "{{ ac_public_ip.ip_address }}"
+
+  - name: 배포 가상머신 인메모리 inventory에 등록
+    add_host:
+      hostname: "{{ ac_public_ip.ip_address }}"
+      groups:
+        - NFSPublicIp
+
+  - name: Create a static NAT for "{{ ac_public_ip.ip_address }}" to "{{ nfs_storage_vm_nm }}"
+    cs_staticnat:
+      api_url: "{{ lookup('env', 'MOLD_API_URL') }}"
+      api_key: "{{ lookup('env', 'MOLD_API_KEY') }}"
+      api_secret: "{{ lookup('env', 'MOLD_SECRET_KEY') }}"
+      ip_address: "{{ ac_public_ip.ip_address }}"
+      zone: "{{ lookup('env', 'MOLD_ZONE_NAME') }}"
+      vm: "{{ nfs_storage_vm_nm }}"
+    delegate_to: localhost
+
+  - name: Allow port for public ip
+    cs_firewall:
+      api_url: "{{ lookup('env', 'MOLD_API_URL') }}"
+      api_key: "{{ lookup('env', 'MOLD_API_KEY') }}"
+      api_secret: "{{ lookup('env', 'MOLD_SECRET_KEY') }}"
+      ip_address: "{{ ac_public_ip.ip_address }}"
+      zone: "{{ lookup('env', 'MOLD_ZONE_NAME') }}"
+      start_port: "{{ item.port }}"
+      end_port: "{{ item.port }}"
+      protocol: "{{ item.protocol }}"
+    with_items:
+        - {port: 80, protocol: tcp}
+        - {port: 22, protocol: tcp}
+        - {port: 3000, protocol: tcp}
+        - {port: 8080, protocol: tcp}
+        - {port: 6443, protocol: tcp}
+        - {port: 8443, protocol: tcp}
+        - {port: 111, protocol: tcp}
+        - {port: 2049, protocol: tcp}
+    delegate_to: localhost
+
+### Deploy NFS Server ###
+- name: Deploy Gitea
+  hosts: NFSPublicIp
+  gather_facts: no
+  vars:
+    - ansible_user: root
+    - ansible_ssh_pass: Ablecloud1!
+
+    - kubectl_version: v1.26.0
+
+  tasks:
+  - name: kubectl 설치
+    shell: | 
+      curl -LO "https://dl.k8s.io/release/{{ kubectl_version }}/bin/linux/amd64/kubectl"
+      install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+
+  - name: Create a directory if it does not exist
+    file:
+      path: /root/.kube/
+      state: directory
+      mode: '0644'
+
+  - name: Creating a file with content kubeconfig
+    copy:
+      dest: "/root/.kube/config"
+      content: |
+        {{ kubeconfig }}
+
+  - name: Creating a file with content persistence volume
+    copy:
+      dest: "/root/pv-create.yaml"
+      content: |
+        apiVersion: v1
+        kind: PersistentVolume
+        metadata:
+          name: nfs-pc
+        spec:
+          capacity:
+            storage: 100Gi
+          accessModes:
+            - ReadWriteMany
+          nfs:
+            server: {{ inventory_hostname }}
+            path: /nfs
+
+  - name: Creating a file with content persistence volume claim
+    copy:
+      dest: "/root/pvc-create.yaml"
+      content: |
+        kind: PersistentVolumeClaim
+        apiVersion: v1
+        metadata:
+          name: nfs-pvc
+        spec:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 100Gi
+
+  - name: Deployment pv, pvc
+    shell: | 
+      kubectl apply -f pv-create.yaml
+      kubectl apply -f pvc-create.yaml

--- a/playbook/nfs_pv/nfs_pv_deploy.yml
+++ b/playbook/nfs_pv/nfs_pv_deploy.yml
@@ -14,6 +14,7 @@
   - name: debug instance_nm stdout
     set_fact:
       nfs_storage_vm_nm: "{{ nfs_storage_vm }}-{{uuid}}"
+      nfs_data_disk_nm: "nfs-data-disk-{{uuid}}"
 
   - name: 가상머신 생성 "{{ nfs_storage_vm_nm }}"
     cs_instance:
@@ -24,19 +25,11 @@
       name: "{{ nfs_storage_vm_nm }}"
       template: "{{ nfs_storage_vm_temp }}"
       service_offering: "{{ instance_computeoffer }}"
-      disk_offering: "{{ disk_offering }}"
       ssh_key: "{{ lookup('env', 'MOLD_SSH_KEYPAIR') }}"
       user_data: |
           #cloud-config
           disable_root: false
           ssh_pwauth: true
-          runcmd:
-          - dnf install -y nfs-utils
-          - mkfs.ext4 /dev/sdb
-          - mkdir /nfs
-          - mount /dev/sdb /nfs
-          - echo "/nfs 10.10.0.0/16(rw,no_root_squash)" >> /etc/exports
-          - systemctl restart nfs-server
       networks: "{{ lookup('env', 'AC_NETWORK_NAME') }}"
     register: vm
 
@@ -53,6 +46,17 @@
       name: "{{ nfs_storage_vm_nm }}"
     delegate_to: localhost
     register: vm
+
+  - name: create/attach volume to instance
+    cs_volume:
+      api_url: "{{ lookup('env', 'MOLD_API_URL') }}"
+      api_key: "{{ lookup('env', 'MOLD_API_KEY') }}"
+      api_secret: "{{ lookup('env', 'MOLD_SECRET_KEY') }}"
+      zone: "{{ lookup('env', 'MOLD_ZONE_NAME') }}"
+      name: "{{ nfs_data_disk_nm }}"
+      disk_offering: "{{ disk_offering }}"
+      vm: "{{ nfs_storage_vm_nm }}"
+      state: attached
 
   - name: 배포 가상머신 ip 정보 수집
     debug:
@@ -119,6 +123,16 @@
     - kubectl_version: v1.26.0
 
   tasks:
+
+  - name: Deployment pv, pvc
+    shell: | 
+      dnf install -y nfs-utils
+      mkfs.ext4 /dev/sdb
+      mkdir /nfs
+      mount /dev/sdb /nfs
+      echo "/nfs 10.10.0.0/16(rw,no_root_squash)" >> /etc/exports
+      systemctl restart nfs-server
+
   - name: kubectl 설치
     shell: | 
       curl -LO "https://dl.k8s.io/release/{{ kubectl_version }}/bin/linux/amd64/kubectl"

--- a/playbook/nfs_pv/nfs_pv_deploy_survey.json
+++ b/playbook/nfs_pv/nfs_pv_deploy_survey.json
@@ -1,0 +1,67 @@
+{
+"name": "",
+"description": "",
+"spec": [
+  {
+    "question_name": "쿠버네티스 클러스터 정보를 입력하세요. (kubeconfig)",
+    "question_description": "Mold -> 컴퓨트 -> 쿠버네티스 -> 액세스 탭의 쿠버네티스 클러스터 정보를 복사하여 붙여주세요.",
+    "required": true,
+    "type": "textarea",
+    "variable": "kubeconfig",
+    "min": 0,
+    "max": 10000000,
+    "default": "",
+    "choices": "",
+    "new_question": false
+  },
+  {
+    "question_name": "NFS Storage VM 명",
+    "question_description": "NFS Storage VM 이름을 입력하세요",
+    "required": true,
+    "type": "text",
+    "variable": "nfs_storage_vm",
+    "min": 0,
+    "max": 1024,
+    "default": "nfs-storage-vm",
+    "choices": "",
+    "new_question": false
+  },
+  {
+    "question_name": "NFS Storage VM을 배포 템플릿 명",
+    "question_description": "NFS Storage VM을 배포하기 위한 템플릿의 이름을 입력하세요",
+    "required": true,
+    "type": "text",
+    "variable": "nfs_storage_vm_temp",
+    "min": 0,
+    "max": 1024,
+    "default": "CentOS-8-cloudinit",
+    "choices": "",
+    "new_question": false
+  },
+  {
+    "question_name": "NFS Storage VM 오퍼링 명",
+    "question_description": "NFS Storage VM을 배포하기 위한 오퍼링 이름을 입력하세요",
+    "required": true,
+    "type": "text",
+    "variable": "instance_computeoffer",
+    "min": 0,
+    "max": 1024,
+    "default": "1C-2GB-RBD-HA",
+    "choices": "",
+    "new_question": false
+  },
+  {
+    "question_name": "NFS Storage VM 데이터 디스크 오퍼링 명",
+    "question_description": "NFS Storage VM을 배포하기 위한 디스크 오퍼링 이름을 입력하세요",
+    "required": true,
+    "type": "text",
+    "variable": "disk_offering",
+    "min": 0,
+    "max": 1024,
+    "default": "100GB-WB-RBD",
+    "choices": "",
+    "new_question": false
+  }
+]
+}
+

--- a/playbook/pipeline/pipeline_deploy.yml
+++ b/playbook/pipeline/pipeline_deploy.yml
@@ -1,0 +1,304 @@
+---
+### Deploy VirtualMachine ###
+- name: Genie를 활용한 Mold VM 배포 - gitea
+  hosts: localhost
+  gather_facts: no
+  vars:
+    # instance_nm: "{{ gitea_instance_name }}-{{ uuid }}"
+    base_path: "genie"
+    genie_ip: "localhost"
+  tasks:
+
+  - name: debug uuid stdout
+    set_fact:
+      uuid: "{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=5') }}"
+  - name: debug instance_nm stdout
+    set_fact:
+      gitea_instance_nm: "{{ gitea_instance_nm }}-{{uuid}}"
+
+  - name: 가상머신 생성 "{{ gitea_instance_nm }}"
+    cs_instance:
+      api_url: "{{ lookup('env', 'MOLD_API_URL') }}"
+      api_key: "{{ lookup('env', 'MOLD_API_KEY') }}"
+      api_secret: "{{ lookup('env', 'MOLD_SECRET_KEY') }}"
+      zone: "{{ lookup('env', 'MOLD_ZONE_NAME') }}"
+      name: "{{ gitea_instance_nm }}"
+      template: "{{ gitea_instance_temp }}"
+      service_offering: "{{ instance_computeoffer }}"
+      ssh_key: "{{ lookup('env', 'MOLD_SSH_KEYPAIR') }}"
+      user_data: |
+          #cloud-config
+          disable_root: false
+          ssh_pwauth: true
+      networks: "{{ lookup('env', 'AC_NETWORK_NAME') }}"
+    register: vm
+
+  - name: 생성한 가상머신이 부팅이 완료될 때까지 대기
+    wait_for_connection:
+      delay: 20
+      timeout: 300
+
+  - name: 배포한 가상머신 정보 수집
+    cs_instance_info:
+      api_url: "{{ lookup('env', 'MOLD_API_URL') }}"
+      api_key: "{{ lookup('env', 'MOLD_API_KEY') }}"
+      api_secret: "{{ lookup('env', 'MOLD_SECRET_KEY') }}"
+      name: "{{ gitea_instance_nm }}"
+    delegate_to: localhost
+    register: vm
+
+  - name: 배포 가상머신 ip 정보 수집
+    debug:
+      msg: "{{ vm.instances[0].nic[0].ipaddress }}"
+
+  - name: Create Public IP
+    cs_ip_address:
+      api_url: "{{ lookup('env', 'MOLD_API_URL') }}"
+      api_key: "{{ lookup('env', 'MOLD_API_KEY') }}"
+      api_secret: "{{ lookup('env', 'MOLD_SECRET_KEY') }}"
+      zone: "{{ lookup('env', 'MOLD_ZONE_NAME') }}"
+      network: "{{ lookup('env', 'AC_NETWORK_NAME') }}"
+    register: ac_public_ip
+
+  - name: Public IP 정보 수집
+    debug:
+      msg: "{{ ac_public_ip.ip_address }}"
+
+  - name: 배포 가상머신 인메모리 inventory에 등록
+    add_host:
+      hostname: "{{ ac_public_ip.ip_address }}"
+      groups:
+        - GiteaPublicIp
+
+  - name: Create a static NAT for "{{ ac_public_ip.ip_address }}" to "{{ gitea_instance_nm }}"
+    cs_staticnat:
+      api_url: "{{ lookup('env', 'MOLD_API_URL') }}"
+      api_key: "{{ lookup('env', 'MOLD_API_KEY') }}"
+      api_secret: "{{ lookup('env', 'MOLD_SECRET_KEY') }}"
+      ip_address: "{{ ac_public_ip.ip_address }}"
+      zone: "{{ lookup('env', 'MOLD_ZONE_NAME') }}"
+      vm: "{{ gitea_instance_nm }}"
+    delegate_to: localhost
+
+  - name: Allow port for public ip
+    cs_firewall:
+      api_url: "{{ lookup('env', 'MOLD_API_URL') }}"
+      api_key: "{{ lookup('env', 'MOLD_API_KEY') }}"
+      api_secret: "{{ lookup('env', 'MOLD_SECRET_KEY') }}"
+      ip_address: "{{ ac_public_ip.ip_address }}"
+      zone: "{{ lookup('env', 'MOLD_ZONE_NAME') }}"
+      start_port: "{{ item.port }}"
+      end_port: "{{ item.port }}"
+      protocol: "{{ item.protocol }}"
+    with_items:
+        - {port: 80, protocol: tcp}
+        - {port: 22, protocol: tcp}
+        - {port: 3000, protocol: tcp}
+        - {port: 3306, protocol: tcp}
+    delegate_to: localhost
+
+### Deploy DB Server ###
+- name: Deploy Gitea
+  hosts: GiteaPublicIp
+  gather_facts: no
+  vars:
+    - ansible_user: root
+    - ansible_ssh_pass: Ablecloud1!
+
+  tasks:
+  - name: Update Gitea config file
+    lineinfile:
+      path: "/etc/gitea/gitea.ini"
+      regexp: "{{item.regexp}}"
+      line: "{{item.line}}"
+    with_items:
+      - {'regexp': '^ROOT_URL', line: 'ROOT_URL              = http://{{ inventory_hostname }}:3000'}
+
+  - name: Start gitea service
+    systemd: name=gitea state=restarted
+
+
+
+
+#=============================================================
+
+### Deploy VirtualMachine ###
+- name: Genie를 활용한 Mold VM 배포 - jenkins
+  hosts: localhost
+  gather_facts: no
+  vars:
+    # instance_nm: "{{ gitea_instance_name }}-{{ uuid }}"
+    base_path: "genie"
+    genie_ip: "localhost"
+  tasks:
+
+  - name: debug uuid stdout
+    set_fact:
+      uuid: "{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=5') }}"
+  - name: debug instance_nm stdout
+    set_fact:
+      jenkins_instance_nm: "{{ jenkins_instance_nm }}-{{uuid}}"
+
+  - name: 가상머신 생성 "{{ jenkins_instance_nm }}"
+    cs_instance:
+      api_url: "{{ lookup('env', 'MOLD_API_URL') }}"
+      api_key: "{{ lookup('env', 'MOLD_API_KEY') }}"
+      api_secret: "{{ lookup('env', 'MOLD_SECRET_KEY') }}"
+      zone: "{{ lookup('env', 'MOLD_ZONE_NAME') }}"
+      name: "{{ jenkins_instance_nm }}"
+      template: "{{ jenkins_instance_temp }}"
+      service_offering: "{{ instance_computeoffer }}"
+      ssh_key: "{{ lookup('env', 'MOLD_SSH_KEYPAIR') }}"
+      user_data: |
+          #cloud-config
+          disable_root: false
+          ssh_pwauth: true
+      networks: "{{ lookup('env', 'AC_NETWORK_NAME') }}"
+    register: vm
+
+  - name: 생성한 가상머신이 부팅이 완료될 때까지 대기
+    wait_for_connection:
+      delay: 20
+      timeout: 300
+
+  - name: 배포한 가상머신 정보 수집
+    cs_instance_info:
+      api_url: "{{ lookup('env', 'MOLD_API_URL') }}"
+      api_key: "{{ lookup('env', 'MOLD_API_KEY') }}"
+      api_secret: "{{ lookup('env', 'MOLD_SECRET_KEY') }}"
+      name: "{{ jenkins_instance_nm }}"
+    delegate_to: localhost
+    register: vm
+
+  - name: 배포 가상머신 ip 정보 수집
+    debug:
+      msg: "{{ vm.instances[0].nic[0].ipaddress }}"
+
+  - name: Create Public IP
+    cs_ip_address:
+      api_url: "{{ lookup('env', 'MOLD_API_URL') }}"
+      api_key: "{{ lookup('env', 'MOLD_API_KEY') }}"
+      api_secret: "{{ lookup('env', 'MOLD_SECRET_KEY') }}"
+      zone: "{{ lookup('env', 'MOLD_ZONE_NAME') }}"
+      network: "{{ lookup('env', 'AC_NETWORK_NAME') }}"
+    register: ac_public_ip
+
+  - name: Public IP 정보 수집
+    debug:
+      msg: "{{ ac_public_ip.ip_address }}"
+
+  - name: 배포 가상머신 인메모리 inventory에 등록
+    add_host:
+      hostname: "{{ ac_public_ip.ip_address }}"
+      groups:
+        - JenkinsPublicIp
+
+  - name: Create a static NAT for "{{ ac_public_ip.ip_address }}" to "{{ jenkins_instance_nm }}"
+    cs_staticnat:
+      api_url: "{{ lookup('env', 'MOLD_API_URL') }}"
+      api_key: "{{ lookup('env', 'MOLD_API_KEY') }}"
+      api_secret: "{{ lookup('env', 'MOLD_SECRET_KEY') }}"
+      ip_address: "{{ ac_public_ip.ip_address }}"
+      zone: "{{ lookup('env', 'MOLD_ZONE_NAME') }}"
+      vm: "{{ jenkins_instance_nm }}"
+    delegate_to: localhost
+
+  - name: Allow port for public ip
+    cs_firewall:
+      api_url: "{{ lookup('env', 'MOLD_API_URL') }}"
+      api_key: "{{ lookup('env', 'MOLD_API_KEY') }}"
+      api_secret: "{{ lookup('env', 'MOLD_SECRET_KEY') }}"
+      ip_address: "{{ ac_public_ip.ip_address }}"
+      zone: "{{ lookup('env', 'MOLD_ZONE_NAME') }}"
+      start_port: "{{ item.port }}"
+      end_port: "{{ item.port }}"
+      protocol: "{{ item.protocol }}"
+    with_items:
+        - {port: 80, protocol: tcp}
+        - {port: 22, protocol: tcp}
+        - {port: 3000, protocol: tcp}
+        - {port: 8080, protocol: tcp}
+        - {port: 6443, protocol: tcp}
+        - {port: 8443, protocol: tcp}
+    delegate_to: localhost
+
+### jenkins ###
+- name: Deploy jenkins
+  hosts: JenkinsPublicIp
+  gather_facts: no
+  vars:
+    - ansible_user: root
+    - ansible_ssh_pass: Ablecloud1!
+
+    #MySQL Settings
+    - login_user: root
+    - login_password: Ablecloud1!
+    - login_db: gitea
+  tasks:
+
+  # gitea 변경
+  - name: 배포한 gitea 가상머신 정보 수집("{{ gitea_instance_nm }}")
+    cs_instance_info:
+      api_url: "{{ lookup('env', 'MOLD_API_URL') }}"
+      api_key: "{{ lookup('env', 'MOLD_API_KEY') }}"
+      api_secret: "{{ lookup('env', 'MOLD_SECRET_KEY') }}"
+      name: "{{ gitea_instance_nm }}"
+    delegate_to: localhost
+    register: gitea_vm
+
+  - name: 배포 gitea 가상머신 ip 정보 수집
+    debug:
+      msg: "{{ gitea_vm.instances[0].public_ip }}"
+
+  - name: Update MySQL Data (Webhook ip)
+    community.mysql.mysql_query:
+      query:
+      - UPDATE webhook SET url = "http://{{ inventory_hostname }}:8080/gitea-webhook/post?job=gxRest" WHERE id =1
+      login_host: "{{ gitea_vm.instances[0].public_ip }}"
+      login_db: "{{ login_db }}"
+      login_user: "{{ login_user }}"
+      login_password: "{{ login_password }}"
+    delegate_to: localhost
+
+  - name: Update jenkins file (gitea server)
+    lineinfile:
+      path: "/var/lib/jenkins/org.jenkinsci.plugin.gitea.servers.GiteaServers.xml"
+      regexp: "{{item.regexp}}"
+      line: "{{item.line}}"
+    with_items:
+      - {'regexp': '^      <serverUrl>', line: '      <serverUrl>http://{{ gitea_vm.instances[0].public_ip }}:3000</serverUrl>'}
+
+  - name: Update jenkins file (gitea repo item)
+    lineinfile:
+      path: "/var/lib/jenkins/jobs/ablecloud-k8s/config.xml"
+      regexp: "{{item.regexp}}"
+      line: "{{item.line}}"
+    with_items:
+      - {'regexp': '^        <url>', line: '        <url>http://{{ gitea_vm.instances[0].public_ip }}:3000/ablecloud/ablecloud.git</url>'}
+
+  - name: Update jenkins file (jenkins addr-1)
+    lineinfile:
+      path: "/var/lib/jenkins/config.xml"
+      regexp: "{{item.regexp}}"
+      line: "{{item.line}}"
+    with_items:
+      - {'regexp': '^      <jenkinsUrl>', line: '      <jenkinsUrl>http://{{ inventory_hostname }}:8080/</jenkinsUrl>'}
+
+  - name: Update jenkins file (jenkins addr-2)
+    lineinfile:
+      path: "/var/lib/jenkins/jenkins.model.JenkinsLocationConfiguration.xml"
+      regexp: "{{item.regexp}}"
+      line: "{{item.line}}"
+    with_items:
+      - {'regexp': '^  <jenkinsUrl>', line: '  <jenkinsUrl>http://{{ inventory_hostname }}:8080/</jenkinsUrl>'}
+
+  - name: Update jenkins file (k8s addr)
+    lineinfile:
+      path: "/var/lib/jenkins/config.xml"
+      regexp: "{{item.regexp}}"
+      line: "{{item.line}}"
+    with_items:
+      - {'regexp': '^      <serverUrl>', line: '      <serverUrl>https://{{ k8s_addr }}:6443</serverUrl>'}
+
+  - name: Restart jenkins service
+    systemd: name=jenkins state=restarted

--- a/playbook/template/template_deploy.yml
+++ b/playbook/template/template_deploy.yml
@@ -169,6 +169,7 @@
   #     controller_username: admin
   #     controller_password: "{{ admin_password.stdout }}"    
 
+# pipeline
   - name: Create pipeline deploy playbook
     awx.awx.job_template:
       name: Pipeline - 구축 (Gitea, Jenkins, k8s)
@@ -190,3 +191,21 @@
         jenkins_instance_nm: "jenkins-pipeline-instance-nm-01"
         jenkins_instance_temp: "genie-pipeline-jenkins-cloudinit"
         instance_computeoffer: "1C-2GB-RBD-HA"
+
+# NFS-PV
+  - name: Create pipeline deploy playbook
+    awx.awx.job_template:
+      name: NFS_PV Storage - 구축
+      description: NFS_PV Storage - 구축
+      job_type: "run"
+      inventory: Genie Inventory
+      project: Genie Git Project
+      playbook: playbook/pipeline/nfs_pv_deploy_survey.yml
+      credentials:
+        - "Automation Controller Credential"
+      state: "present"
+      controller_host: "http://{{ genie_ip }}:80"
+      controller_username: admin
+      controller_password: "{{ admin_password.stdout }}"
+      survey_enabled: yes
+      survey_spec: "{{ lookup('file', './nfs_pv_deploy_survey.json') }}"

--- a/playbook/template/template_deploy.yml
+++ b/playbook/template/template_deploy.yml
@@ -168,3 +168,25 @@
   #     controller_host: "http://{{ genie_ip }}:80"
   #     controller_username: admin
   #     controller_password: "{{ admin_password.stdout }}"    
+
+  - name: Create pipeline deploy playbook
+    awx.awx.job_template:
+      name: Pipeline - 구축 (Gitea, Jenkins, k8s)
+      description: CI/CD를 위한 파이프라인(Gitea, Jenkins, k8s)을 구성합니다.
+      job_type: "run"
+      inventory: Genie Inventory
+      project: Genie Git Project
+      playbook: playbook/pipeline/pipeline_deploy.yml
+      credentials:
+        - "Automation Controller Credential"
+      state: "present"
+      controller_host: "http://{{ genie_ip }}:80"
+      controller_username: admin
+      controller_password: "{{ admin_password.stdout }}"
+      extra_vars: 
+        k8s_addr: "10.10.10.10"
+        gitea_instance_nm: "gitea-pipeline-instance-nm-01"
+        gitea_instance_temp: "genie-pipeline-gitea-cloudinit"
+        jenkins_instance_nm: "jenkins-pipeline-instance-nm-01"
+        jenkins_instance_temp: "genie-pipeline-jenkins-cloudinit"
+        instance_computeoffer: "1C-2GB-RBD-HA"


### PR DESCRIPTION
### PR 설명



- [x] Pipeline - 구축 (Gitea, Jenkins, k8s)
  CI/CD를 위한 파이프라인(Gitea, Jenkins, k8s)을 구성합니다.

- [x] NFS-PV 연동 스토리지 구축
  DATA 디스크 (100GB)

<!--- 변경 사항에 대해 자세하게 설명하십시오. 그리고 변경사항을 어떻게 실행하는지도 설명합니다. -->
<!-- 새로운 기능에 대한 PR인 경우, 타당성 조사(FS) 및 디자인 컨셉(DS) 등에 대한 위키 또는 문서 등을 링크합니다. -->
<!-- 버그 수정에 대한 PR인 경우, 재현을 위한 과정과 기대 실행 및 실제 실행 결과에 대한 내용을 설명합니다. -->

<!-- "Fixes #<id>"를 사용하면 해당 이슈 및 PR이 관련 이슈/PR로 등록되어 PR이 Merge 될 때 자동으로 종료됩니다. -->
<!-- 여려 개의 이슈 또는 PR을 지정하고자 하는 경우, 여러 개의 "Fixes #<id>"를 작성합니다. -->
<!-- Fixes # -->


### 변경 구분

- [ ] 잠재적 기능/오류 개선 (기존의 기능에 잠재되어 있는 오류 또는 다른 기능에 영향을 미칠 기능의 개선)
- [x] 새로운 기능 (다른 기능에 영향을 미치지 않는 새 기능)
- [ ] 버그 수정 (이슈에 보고된 버그에 대한 수정으로 다른 기능에 영향을 미치지 않음)
- [ ] 기능 개선 (기존 기능에 대한 개선으로 다른 기능에 영향을 미치지 않음)
- [ ] 코드 청소 (코드 재구성 및 청소, 테스트 케이스 추가 등)

### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [ ] 주요 기능/개선
- [x] 소규모 기능/개선

#### 버그 심각도

- [ ] 매우 심각 (제품 출시/운영을 불가능하게 함)
- [ ] 위험 (사용자에게 자원의 손실을 가져오게 함)
- [ ] 중요 (사용자에게 기능 사용의 불편을 가져오게 함)
- [ ] 보통 (사용자가 문제를 인지할 수 있을 정도임)
- [ ] 미미 (사용자가 인지하지 못할 정도임)


### 스크린샷


### 테스트 방법 및 결과

<!-- 변경사항에 대해 어떻게 테스트 되었는지 상세하게 기재합니다. -->
<!-- 테스트 환경, 실행 구성 등을 자세하게 내용에 포함합니다. -->
<!-- 변경사항이 영향을 미치는 다른 영역, 예를 들어 화면, 코드 등을 같이 볼 수 있도록 합니다. -->

**Pipeline - 구축**

Gitea addr: http://<public ip>:3000
Jenkins addr: http://<public ip>:8080
<public ip>는 Mold 및 지니 템플릿 작동 후 로그에서 확인할 수 있습니다.

1. k8s 클러스터를 배포합니다.
2. 오토메이션컨트롤러를 배포합니다.
3. pipeline 구축에 필요한 이미지 템플릿을 다운로드합니다.
	genie-pipeline-gitea-cloudinit.qcow2, genie-pipeline-jenkins-cloudinit.qcow2
4. 오토메이션컨트롤러 대시보드 템플릿 메뉴에서 
	- "Genie 템플릿 리스트 불러오기 및 업데이트" 를 실행합니다.
	- "Pipeline - 구축 (Gitea, Jenkins, k8s)" 편집하여 사전 배포된 변수 "k8s_addr" 아이피를 입력하고 오퍼링을 확인합니다. 
	- "Pipeline - 구축 (Gitea, Jenkins, k8s)"를 실행합니다.
		- 하나의 오토메이션 컨트롤러에서 파이프라인을 여러개 생성하기 위해서 변수 gitea_instance_nm 와 jenkins_instance_nm를 다른 이름으로 변경해야 합니다.
5. "Jenkins"에서
	- 로그인을 합니다. (아이디: ablecloud, 비번: Ablecloud1!)
	- 사전 배포된 k8s의 kubeconfig파일을 다운로드하여 jenkins의 인증정보로 등록합니다.
		- Jenkins 관리 -> Manage Credentials -> Stores scoped to Jenkins의 System -> Global credentials -> Add Credentials
			- Kind: Secret file
			- File: kubeconfig를 업로드 합니다.
6. "Gitea"에서
	- 로그인을 합니다. (아이디: ablecloud, 비번: Ablecloud1!)
	- ablecloud/ablecloud 저장소의 소스를 편집하고 커밋합니다.
7. "Jenkins"에서 테스트 maven-build가 정상작동 되는 지 확인합니다.




** NFS-PV 연동 스토리지 - 구축**
1. k8s 클러스터를 배포합니다.
2. 오토메이션컨트롤러를 배포합니다.
3. NFS-PV 연동 스토리지 - 구축에 필요한 이미지 템플릿을 다운로드합니다.
	CentOS-8-cloudinit.qcow2
4. 오토메이션컨트롤러 대시보드 템플릿 메뉴에서 
	- "Genie 템플릿 리스트 불러오기 및 업데이트" 를 실행합니다.
	- "NFS_PV Storage - 구축"를 실행합니다.
		- 사전에 구축한 k8s의 쿠버네티스 클러스터 정보를  복사하여 입력합니다. (kubeconfig)
		- 나머지 변수는 디폴트 값으로 설정합니다.
5. 자동으로 NFS VM의 "/nfs" 경로의 스토리지를 사전에 배포한 쿠버네티스 환경에 pv와 pvc를 생성하여 연동합니다.
